### PR TITLE
Docker cache and workflow rename

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,10 +33,33 @@ jobs:
     runs-on: ubuntu-latest
     needs: lint
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
       - name: Login to DockerHub Registry
         run: echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
-      - name: Build the Docker image
-        run: docker build -t silentimp/currencyconvertor .
-      - name: Push the Docker image to the registry
-        run: docker push silentimp/currencyconvertor
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: false
+          tags: silentimp/currencyconvertor:latest
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new
+
+      - name: Move cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,4 +1,4 @@
-name: Test
+name: Test and Deploy Workflow
 
 on:
   push:
@@ -7,7 +7,7 @@ on:
 
 jobs:
   lint:
-    name: Lint and test code
+    name: Lint code
     runs-on: ubuntu-latest
 
     steps:
@@ -24,14 +24,31 @@ jobs:
 
       - name: Lint
         run: npm run lint
+
+  test:
+    name: Test code
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
       
+      - name: Use Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: '14.x'
+
+      - name: Install dependencies
+        run: npm ci
+
       - name: Test
         run: npm t
 
-  build:
+  deploy:
     name: Deploy
+    if: github.event.pull_request.merged
     runs-on: ubuntu-latest
-    needs: lint
+    needs: [lint, test]
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -54,7 +71,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
-          push: false
+          push: true
           tags: silentimp/currencyconvertor:latest
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new

--- a/components/ConvertorForm/ConvertorForm.jsx
+++ b/components/ConvertorForm/ConvertorForm.jsx
@@ -136,6 +136,7 @@ const ConvertorForm = ({
         type="submit"
         formAction="/?switch=true"
         className={styles.ConvertorForm__Switch}
+        tabIndex="0"
       >
         Switch
       </button>


### PR DESCRIPTION
# Cache

This would allow to use of docker layer cache and build much faster than before.

The article related to this: https://evilmartians.com/chronicles/build-images-on-github-actions-with-docker-layer-caching

This improve the time of image build on 2+ run from 65 to 20 seconds ~

# Parallelize

Separation of linting and testing improve overall time of test stage from 38 seconds to 25 seconds.
